### PR TITLE
fix getUsername from SharedPreferences

### DIFF
--- a/audio_call/lib/services/auth_service.dart
+++ b/audio_call/lib/services/auth_service.dart
@@ -70,7 +70,7 @@ class AuthService {
 
   Future<String> getUsername() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
-    return prefs.getString('username').replaceAll('.voximplant.com', '');
+    return prefs.getString('username')?.replaceAll('.voximplant.com', '');
   }
 
   Future<void> _saveAuthDetails(String username, LoginTokens loginTokens) async {


### PR DESCRIPTION
or have exception
```
Exception has occurred.
NoSuchMethodError (NoSuchMethodError: The method 'replaceAll' was called on null.
Receiver: null
Tried calling: replaceAll(".voximplant.com", ""))
```